### PR TITLE
Handle different types of results in ExecuteScript

### DIFF
--- a/TomLonghurst.Selenium.PlaywrightWebDriver.Tests/TomLonghurst.Selenium.PlaywrightWebDriver.Tests.csproj
+++ b/TomLonghurst.Selenium.PlaywrightWebDriver.Tests/TomLonghurst.Selenium.PlaywrightWebDriver.Tests.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
 


### PR DESCRIPTION
Fixes bug #108 

Note: I added 4 tests, one for primitive types and one for array - both work. And two additional tests, one for native JavaScript objects and the other for IWebElement which I couldn't make them to work, so I annotated them with [Ignore] for documentation purposes. If you have an idea how to make them work too, it would be great. But without them there's still a lot of value for me in this PR.