### PR TITLE
Switch NuGet publishing to trusted publishing

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -20,6 +20,9 @@ jobs:
   pipeline:
     environment: ${{ github.ref == 'refs/heads/main' && 'Production' || 'Pull Requests' }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
 
     steps:
       - uses: actions/checkout@v7.0.1
@@ -37,9 +40,16 @@ jobs:
           key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj') }}
           restore-keys: |
             ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj') }}
+      - name: NuGet login
+        if: ${{ github.ref == 'refs/heads/main' && github.event.inputs.publish-packages == 'true' }}
+        uses: NuGet/login@v1
+        id: login
+        with:
+          user: ${{ secrets.NUGET_USER }}
+
       - name: Run Pipeline
         run: dotnet run -c Release --framework net10.0
         working-directory: "TomLonghurst.Selenium.PlaywrightWebDriver.Pipeline"
         env:
-          NuGet__ApiKey: ${{ github.ref == 'refs/heads/main' && secrets.NUGET__APIKEY || null }}
+          NuGet__ApiKey: ${{ steps.login.outputs.NUGET_API_KEY }}
           NuGet__ShouldPublish: ${{ github.event.inputs.publish-packages || false }}


### PR DESCRIPTION
## Summary
- request GitHub OIDC tokens for NuGet trusted publishing
- use NuGet/login@v1 with ${{ secrets.NUGET_USER }} to exchange for a short-lived NuGet API key
- pass steps.login.outputs.NUGET_API_KEY into the existing publish step or pipeline input

## Validation
- parsed the modified workflow YAML files locally
- ran git diff --check

## Follow-up
A matching trusted publishing policy must be configured on nuget.org for this repository and workflow file before the next publish run.